### PR TITLE
Update to Minecraft 1.20.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,9 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
-	modImplementation "fi.dy.masa.malilib:malilib-fabric-1.20.2:${project.malilib_version}"
+	modImplementation "fi.dy.masa.malilib:malilib-fabric-1.20.4:${project.malilib_version}"
 	//modImplementation "com.github.DarkKronicle:AdvancedChatCore:${project.advancedchat_version}"
-	modImplementation "io.github.darkkronicle:AdvancedChatCore:1.20.2-1.5.10" // only used to build the mod locally
+	modImplementation "io.github.darkkronicle:AdvancedChatCore:1.20.4-1.5.10" // only used to build the mod locally
 
 	implementation 'org.openjdk.nashorn:nashorn-core:15.3'
 	implementation 'org.javadelight:delight-nashorn-sandbox:0.2.5'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
-minecraft_version=1.20.2
-yarn_mappings=1.20.2+build.4
-loader_version=0.14.24
-fabric_api_version=0.90.4+1.20.2
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.3
+loader_version=0.15.3
+fabric_api_version=0.92.0+1.20.4
 
 mod_version=1.2.8
 maven_group=io.github.darkkronicle
 archives_base_name=AdvancedChatFilters
 
-malilib_version = 0.17.0
+malilib_version = 0.18.0
 org.gradle.jvmargs=-Xmx1G
 advancedchat_version=v1.5.10
 owo_version=2.0.0

--- a/src/main/java/io/github/darkkronicle/advancedchatfilters/scripting/util/TextBuilder.java
+++ b/src/main/java/io/github/darkkronicle/advancedchatfilters/scripting/util/TextBuilder.java
@@ -157,7 +157,7 @@ public class TextBuilder {
      * @param value Content of that action
      */
     public TextBuilder setClickEvent(String action, String value) {
-        ClickEvent.Action clickAction = ClickEvent.Action.byName(action);
+        ClickEvent.Action clickAction = ClickEvent.Action.valueOf(action.toUpperCase());
         if (!clickAction.isUserDefinable()) {
             return this;
         }


### PR DESCRIPTION
Thanks again for your port to 1.20/1.20.1 and 1.20.2.
This PR ports the mod to 1.20.4.

Related PRs:
- https://github.com/medisant/AdvancedChatCore/pull/1
- https://github.com/medisant/AdvancedChatHUD/pull/1